### PR TITLE
fix: correct 'Unknonwn' to 'Unknown' typo in MarkWatchedActionViewController

### DIFF
--- a/Rippple/Controllers/Actions/Mark Watched/MarkWatchedActionViewController.swift
+++ b/Rippple/Controllers/Actions/Mark Watched/MarkWatchedActionViewController.swift
@@ -359,7 +359,7 @@ extension MarkWatchedActionViewController {
         } else if indexPath.row == 2 {
             // Unknown
             datePicker?.date = Date(timeIntervalSince1970: 0)
-            dateActionLabel?.text = "Unknonwn"
+            dateActionLabel?.text = "Unknown"
             date = datePicker?.date
         }
 


### PR DESCRIPTION
## Summary
Corrects a typo in the Mark Watched action screen where the date action label text was incorrectly spelled as 'Unknonwn' instead of 'Unknown'.

## Change
- File: `Rippple/Controllers/Actions/Mark Watched/MarkWatchedActionViewController.swift`
- Line 362: `dateActionLabel?.text = "Unknonwn"` → `dateActionLabel?.text = "Unknown"`

## Testing
- Swift syntax verified (1-line surgical change, no functional logic changed)
- Single commit, GH007 compliant

Closes #35.